### PR TITLE
Fix Honda not braking down to 0

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -579,7 +579,7 @@ class Controls:
 
     if not self.joystick_mode:
       # accel PID loop
-      long_active = self.active and CS.cruiseState.enabled
+      long_active = self.active and (CS.cruiseState.enabled or (self.CP.pcmCruise and CS.accEnabled and self.CP.minEnableSpeed > 0 and not CS.cruiseState.enabled))
       pid_accel_limits = self.CI.get_pid_accel_limits(self.CP, CS.vEgo, self.v_cruise_kph * CV.KPH_TO_MS)
       actuators.accel = self.LoC.update(long_active, CS, self.CP, long_plan, pid_accel_limits)
 


### PR DESCRIPTION
Fixes openpilot not braking to zero if using Honda's stock ACC and the speed goes below the ACC minimum engage speed