### PR TITLE
Update Installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Table of Contents
 
 * [Join our Discord](#-join-our-discord-)
 * [Read Before Installing](#-read-before-installing-)
+* [Installation](#-installation)
 * [Highlight Features](#-highlight-features)
 * [Driving Enhancement](#-driving-enhancement)
 * [Branch Definitions](#-branch-definitions)
 * [**✅Recommended Branches✅**](#-recommended-branches)
-* [Installation](#-installation)
 * [How-Tos](#-How-Tos-)
 * [**💰Donate💰**](#-donate-)
 * [Pull Requests](#-Pull-Requests-)
@@ -36,6 +36,34 @@ sunnypilot is recommended to be used for **most** of the following car makes' mo
 * General Motors (**GM**)
 
 It is a fork of [comma.ai's openpilot](https://github.com/commaai/openpilot). By installing this software, you accept all responsibility for anything that might occur while you use it. All contributors to sunnypilot are not liable. ❗<ins>**Use at your own risk.**</ins>❗
+
+
+⚒ Installation
+---
+
+### Comma URL (Comma 3 only quick setup)
+Test-C3 is more stable than 8.14
+Factory reset/uninstall previous software if you already installed a branch
+Select Custom Software
+Input the following URL: installer.comma.ai/sunnyhaibin/test-c3
+
+### Comma 2 / non-test fork for comma 3
+To install sunnyhaibin's fork, simply use the installer.comma.ai URL (thanks [Shane](https://github.com/sshane/openpilot-installer-generator)!) on the setup screen for "Custom Software" after you factory reset or uninstalled sunnypilot from a previous install:
+
+```
+installer.comma.ai/sunnyhaibin/<insert_branch_name>
+```
+For example, if you would like to install the branch for HKG:
+
+* [`0.8.12-prod-full-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-full-hkg):
+    ```
+    installer.comma.ai/0.8.12-prod-full-hkg
+    ```
+
+* [`0.8.12-prod-personal-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-personal-hkg):
+    ```
+    installer.comma.ai/sunnyhaibin/0.8.12-prod-personal-hkg
+    ```
 
 ### Safety Modifications
 All [official sunnypilot branches from sunnypilot's official GitHub repository](https://github.com/sunnyhaibin/sunnypilot/branches) strictly adhere to comma.ai's safety policy.
@@ -229,27 +257,6 @@ Example:
 | [`0.8.14-prod-c3`](https://github.com/sunnyhaibin/sunnypilot/tree/0.8.14-prod-c3) | • Latest production/stable branch<br/>• Based on commaai's openpilot 0.8.14                        | comma three       | [`0.8.14-prod-c3` Changelogs](https://github.com/sunnyhaibin/sunnypilot/blob/0.8.14-prod-c3/CHANGELOGS.md) |
 | [`test-c3`](https://github.com/sunnyhaibin/sunnypilot/tree/test-c3)               | • Latest test branch with experimental features<br/>• Based on commaai's openpilot latest upstream | comma three       | [`test-c3` Changelogs](https://github.com/sunnyhaibin/sunnypilot/blob/test-c3/CHANGELOGS.md)               |
 
-
-⚒ Installation
----
-
-### Smiskol URL (Quickest and Easiest)
-To install sunnyhaibin's fork, simply use the Smiskol URL (thanks [Shane](https://github.com/sshane/openpilot-installer-generator)!) on the setup screen for "Custom Software" after you factory reset or uninstalled sunnypilot from a previous install:
-
-```
-https://smiskol.com/fork/sunnyhaibin/<insert_branch_name>
-```
-For example, if you would like to install the branch for HKG:
-
-* [`0.8.12-prod-full-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-full-hkg):
-    ```
-    https://smiskol.com/fork/sunnyhaibin/0.8.12-prod-full-hkg
-    ```
-
-* [`0.8.12-prod-personal-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-personal-hkg):
-    ```
-    https://smiskol.com/fork/sunnyhaibin/0.8.12-prod-personal-hkg
-    ```
 
 ### SSH (More Versatile)
 If you are looking to install sunnyhaibin's fork via SSH, run the following command in an SSH terminal after connecting to your device:

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ The following changes are a **VIOLATION** and **ARE NOT** included:
 ---
 
 ### Comma URL (Comma 3 only quick setup)
-* 8.14 was last updated in July 2022, many changes have been made since then so test-c3 is recommended
-* Factory reset/uninstall previous software if you already installed a branch
-* Select Custom Software
-* Input the following URL: ```installer.comma.ai/sunnyhaibin/test-c3```
+```
+8.14 was last updated in July 2022, many changes have been made since then so test-c3 is recommended
+1. Factory reset/uninstall previous software if you already installed a branch
+2. Select Custom Software
+3. Input the following URL: installer.comma.ai/sunnyhaibin/test-c3
+```
 
 ### Comma 2 / non-test fork for comma 3
 To install sunnyhaibin's fork, simply use the installer.comma.ai URL (thanks [Shane](https://github.com/sshane/openpilot-installer-generator)!) on the setup screen for "Custom Software" after you factory reset or uninstalled sunnypilot from a previous install:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ sunnypilot is recommended to be used for **most** of the following car makes' mo
 
 It is a fork of [comma.ai's openpilot](https://github.com/commaai/openpilot). By installing this software, you accept all responsibility for anything that might occur while you use it. All contributors to sunnypilot are not liable. ❗<ins>**Use at your own risk.**</ins>❗
 
+### Safety Modifications
+All [official sunnypilot branches from sunnypilot's official GitHub repository](https://github.com/sunnyhaibin/sunnypilot/branches) strictly adhere to comma.ai's safety policy.
+
+The following changes are a **VIOLATION** and **ARE NOT** included:
+* Driver Monitoring
+  * ❌ "Nerfing" or reducing monitoring bounds ❌
+* Panda safety
+  * ❌ No disengaging of <ins>**LONGITUDINAL CONTROL**</ins> (acceleration/brake) on brake pedal press ❌ (was never included in MADS)
+  * ❌ Re-engaging of <ins>**LONGITUDINAL CONTROL**</ins> (acceleration/brake) on brake pedal release ❌ (was never included in MADS)
+  * ❌ No disengaging on ACC MAIN in OFF state ❌
 
 ⚒ Installation
 ---
@@ -64,17 +74,6 @@ For example, if you would like to install the branch for HKG:
     ```
     installer.comma.ai/sunnyhaibin/0.8.12-prod-personal-hkg
     ```
-
-### Safety Modifications
-All [official sunnypilot branches from sunnypilot's official GitHub repository](https://github.com/sunnyhaibin/sunnypilot/branches) strictly adhere to comma.ai's safety policy.
-
-The following changes are a **VIOLATION** and **ARE NOT** included:
-* Driver Monitoring
-  * ❌ "Nerfing" or reducing monitoring bounds ❌
-* Panda safety
-  * ❌ No disengaging of <ins>**LONGITUDINAL CONTROL**</ins> (acceleration/brake) on brake pedal press ❌ (was never included in MADS)
-  * ❌ Re-engaging of <ins>**LONGITUDINAL CONTROL**</ins> (acceleration/brake) on brake pedal release ❌ (was never included in MADS)
-  * ❌ No disengaging on ACC MAIN in OFF state ❌
 
 🚗 Highlight Features
 ---

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ It is a fork of [comma.ai's openpilot](https://github.com/commaai/openpilot). By
 ---
 
 ### Comma URL (Comma 3 only quick setup)
-Test-C3 is more stable than 8.14
-Factory reset/uninstall previous software if you already installed a branch
-Select Custom Software
-Input the following URL: installer.comma.ai/sunnyhaibin/test-c3
+* Test-C3 is more stable than 8.14
+* Factory reset/uninstall previous software if you already installed a branch
+* Select Custom Software
+* Input the following URL: ```installer.comma.ai/sunnyhaibin/test-c3```
 
 ### Comma 2 / non-test fork for comma 3
 To install sunnyhaibin's fork, simply use the installer.comma.ai URL (thanks [Shane](https://github.com/sshane/openpilot-installer-generator)!) on the setup screen for "Custom Software" after you factory reset or uninstalled sunnypilot from a previous install:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following changes are a **VIOLATION** and **ARE NOT** included:
 ```
 
 ### Comma 2 / non-test fork for comma 3
-To install sunnyhaibin's fork, simply use the installer.comma.ai URL (thanks [Shane](https://github.com/sshane/openpilot-installer-generator)!) on the setup screen for "Custom Software" after you factory reset or uninstalled sunnypilot from a previous install:
+To install sunnypilot's fork, simply use the installer.comma.ai URL (thanks [Shane](https://github.com/sshane/openpilot-installer-generator)!) on the setup screen for "Custom Software" after you factory reset or uninstalled sunnypilot from a previous install:
 
 ```
 installer.comma.ai/sunnyhaibin/<insert_branch_name>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The following changes are a **VIOLATION** and **ARE NOT** included:
 ---
 
 ### Comma URL (Comma 3 only quick setup)
-* Test-C3 is more stable than 8.14
+* 8.14 was last updated in July 2022, many changes have been made since then so test-c3 is recommended
 * Factory reset/uninstall previous software if you already installed a branch
 * Select Custom Software
 * Input the following URL: ```installer.comma.ai/sunnyhaibin/test-c3```
@@ -67,7 +67,7 @@ For example, if you would like to install the branch for HKG:
 
 * [`0.8.12-prod-full-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-full-hkg):
     ```
-    installer.comma.ai/0.8.12-prod-full-hkg
+    installer.comma.ai/sunnyhaibin/0.8.12-prod-full-hkg
     ```
 
 * [`0.8.12-prod-personal-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-personal-hkg):

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ The following changes are a **VIOLATION** and **ARE NOT** included:
 ---
 
 ### Comma URL (Comma 3 only quick setup)
-```
+
 8.14 was last updated in July 2022, many changes have been made since then so test-c3 is recommended
+```
 1. Factory reset/uninstall previous software if you already installed a branch
 2. Select Custom Software
 3. Input the following URL: installer.comma.ai/sunnyhaibin/test-c3

--- a/README.md
+++ b/README.md
@@ -63,19 +63,21 @@ The following changes are a **VIOLATION** and **ARE NOT** included:
 ### Comma 2 / non-test fork for comma 3
 To install sunnypilot's fork, simply use the installer.comma.ai URL (thanks [Shane](https://github.com/sshane/openpilot-installer-generator)!) on the setup screen for "Custom Software" after you factory reset or uninstalled sunnypilot from a previous install:
 
+<b>HTTPS://</b> prepend is required for comma 2, This is not required for comma 3!
+
 ```
-installer.comma.ai/sunnyhaibin/<insert_branch_name>
+https://installer.comma.ai/sunnyhaibin/<insert_branch_name>
 ```
 For example, if you would like to install the branch for HKG:
 
 * [`0.8.12-prod-full-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-full-hkg):
     ```
-    installer.comma.ai/sunnyhaibin/0.8.12-prod-full-hkg
+    https://installer.comma.ai/sunnyhaibin/0.8.12-prod-full-hkg
     ```
 
 * [`0.8.12-prod-personal-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-personal-hkg):
     ```
-    installer.comma.ai/sunnyhaibin/0.8.12-prod-personal-hkg
+    https://installer.comma.ai/sunnyhaibin/0.8.12-prod-personal-hkg
     ```
 
 🚗 Highlight Features


### PR DESCRIPTION
Moved installation to top, added quick install instructions for comma 3, switched URL from Smiskol to installer.comma.ai