### PR TITLE
add engine ecu for 2019 subaru impreza

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -137,6 +137,7 @@ FW_VERSIONS = {
       b'\xaa!dt\a',
       b'\xf1\x00\xa2\x10\t',
       b'\xc5!ar\a',
+      b'\xc5!as\x07',
       b'\xbe!as\a',
       b'\xc5!ds\a',
       b'\xc5!`s\a',


### PR DESCRIPTION
Added 2019 Subaru Impreza ECU to enable vehicle recognition. Tested on fork of open pilot master on 11/4.

Validation done on successful drive with fork.

Route
Route: 78c45ff47fdd934b|2022-11-04--18-34-57

see PR https://github.com/commaai/openpilot/pull/26385