### PR TITLE
Pre-Global Subaru: counter fix and disable dashcamOnly

### DIFF
--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -40,7 +40,7 @@ class CarController:
         apply_steer = 0
 
       if self.CP.carFingerprint in PREGLOBAL_CARS:
-        can_sends.append(subarucan.create_preglobal_steering_control(self.packer, apply_steer))
+        can_sends.append(subarucan.create_preglobal_steering_control(self.packer, apply_steer, self.frame, self.p.STEER_STEP))
       else:
         can_sends.append(subarucan.create_steering_control(self.packer, apply_steer))
 

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -12,7 +12,6 @@ class CarInterface(CarInterfaceBase):
   def _get_params(ret, candidate, fingerprint, car_fw, experimental_long):
     ret.carName = "subaru"
     ret.radarUnavailable = True
-    ret.dashcamOnly = candidate in PREGLOBAL_CARS
     ret.autoResumeSng = False
 
     if candidate in PREGLOBAL_CARS:

--- a/selfdrive/car/subaru/subarucan.py
+++ b/selfdrive/car/subaru/subarucan.py
@@ -82,8 +82,12 @@ def subaru_preglobal_checksum(packer, values, addr):
   dat = packer.make_can_msg(addr, 0, values)[2]
   return (sum(dat[:7])) % 256
 
-def create_preglobal_steering_control(packer, apply_steer):
+def create_preglobal_steering_control(packer, apply_steer, frame, steer_step):
+
+  idx = (frame / steer_step) % 8
+
   values = {
+    "COUNTER": idx,
     "LKAS_Command": apply_steer,
     "LKAS_Active": 1 if apply_steer != 0 else 0
   }


### PR DESCRIPTION
Revert legacy `ES_LKAS` counter autogeneration and disable `dashcamOnly` for Pre-Global Subaru platforms.

Thanks to community contributor @martinl!