### PR TITLE
mapd: bring back README

### DIFF
--- a/selfdrive/mapd/README.md
+++ b/selfdrive/mapd/README.md
@@ -1,0 +1,8 @@
+# MapD
+The OpenStreetMap-based speed logical by the [Move Fast team](https://github.com/move-fast), [dragonpilot team](https://github.com/dragonpilot-community/dragonpilot), and additional improvements by [sunnypilot](https://github.com/sunnyhaibin/sunnypilot).
+
+The comma three uses regular SciPy. To have a better experience with `mapd`, please go to [OpenStreetMap](https://openstreetmap.org) to update and improve your area's data (i.e., Speed Limit, Stop Signs, Traffic Lights).
+
+To use `mapd`, you consent to `mapd` uploading the traces. You may opt out of uploading traces at any time.
+
+© OpenStreetMap contributors


### PR DESCRIPTION
This README fell through the cracks during the last major refactor/merge.