### PR TITLE
HKG: support steer to 0 with smartMDPS on certain models

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -312,6 +312,11 @@ class CarInterface(CarInterfaceBase):
     # mass and CG position, so all cars will have approximately similar dyn behaviors
     ret.tireStiffnessFront, ret.tireStiffnessRear = scale_tire_stiffness(ret.mass, ret.wheelbase, ret.centerToFront,
                                                                          tire_stiffness_factor=tire_stiffness_factor)
+
+    # Detect smartMDPS, which bypasses EPS low speed lockout, allowing sunnypilot to send steering commands down to 0
+    if 0x2AA in fingerprint[0]:
+      ret.minSteerSpeed = 0.
+
     return ret
 
   @staticmethod


### PR DESCRIPTION
Detects smartMDPS that emits `0x2AA` to sunnypilot/openpilot. The smartMDPS must flash with the following firmware or equivalent that emits `0x2AA` on bus 0:
- [`sunnyhaibin/panda:sunnypilot_smdps`](https://github.com/sunnyhaibin/panda/tree/sunnypilot_smdps)