### PR TITLE
Enhanced Speed Control: accelerator press state handling

### DIFF
--- a/selfdrive/controls/lib/speed_limit_controller.py
+++ b/selfdrive/controls/lib/speed_limit_controller.py
@@ -198,6 +198,7 @@ class SpeedLimitController():
     self._is_metric = self._params.get_bool("IsMetric")
     self._is_enabled = self._params.get_bool("SpeedLimitControl")
     self._offset_enabled = self._params.get_bool("SpeedLimitPercOffset")
+    self._disengage_on_accelerator = self._params.get_bool("DisengageOnAccelerator")
     self._op_enabled = False
     self._op_enabled_prev = False
     self._v_ego = 0.
@@ -293,7 +294,7 @@ class SpeedLimitController():
 
     # In any case, if op is disabled, or speed limit control is disabled
     # or the reported speed limit is 0 or gas is pressed, deactivate.
-    if not self._op_enabled or not self._is_enabled or self._speed_limit == 0 or self._gas_pressed:
+    if not self._op_enabled or not self._is_enabled or self._speed_limit == 0 or (self._gas_pressed and self._disengage_on_accelerator):
       self.state = SpeedLimitControlState.inactive
       return
 

--- a/selfdrive/controls/lib/vision_turn_controller.py
+++ b/selfdrive/controls/lib/vision_turn_controller.py
@@ -98,6 +98,7 @@ class VisionTurnController():
     self._op_enabled = False
     self._gas_pressed = False
     self._is_enabled = self._params.get_bool("TurnVisionControl")
+    self._disengage_on_accelerator = self._params.get_bool("DisengageOnAccelerator")
     self._last_params_update = 0.
     self._v_cruise_setpoint = 0.
     self._v_ego = 0.
@@ -217,7 +218,7 @@ class VisionTurnController():
 
   def _state_transition(self):
     # In any case, if system is disabled or the feature is disabeld or gas is pressed, disable.
-    if not self._op_enabled or not self._is_enabled or self._gas_pressed:
+    if not self._op_enabled or not self._is_enabled or (self._gas_pressed and self._disengage_on_accelerator):
       self.state = VisionTurnControllerState.disabled
       return
 


### PR DESCRIPTION
When Speed Limit Control and/or Vision Turn Speed Control is engaged, the user manual accelerator press should not disengage the systems if the `Disengage on Accelerator Pedal` toggle is disabled.