### PR TITLE
Ram DT: check EPS firmware explicitly to set minEnableSpeed to 0

### DIFF
--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -64,8 +64,7 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 2493. + STD_CARGO_KG
       ret.minSteerSpeed = 0.5
       ret.minEnableSpeed = 14.5
-      # Certain EPS FW allow steer to zero
-      if any(fw.ecu == 'eps' and (fw.fwVersion[:4] <= b"6831" or fw.fwVersion[:4] <= b"6827") for fw in car_fw):
+      if any(fw.ecu == 'eps' and fw.fwVersion in (b"68273275AF", b"68273275AG", b"68312176AE", b"68312176AG",) for fw in car_fw):
         ret.minEnableSpeed = 0.
 
     elif candidate == CAR.RAM_HD:


### PR DESCRIPTION
The upstream method to check if the first 4 characters of the EPS firmware are smaller than or equal to the defined bounds to set `minEnableSpeed = 0.` would not work for some Ram DT.

Affected route: `001ccccec7a1992c|2023-06-07--21-25-45`
EPS FW: `b'21590101AA'`

Only allow `minEnableSpeed = 0.` for the EPS firmware that is known to allow enable steering at 0.