### PR TITLE
nav: Local Webserver Enhancements

### DIFF
--- a/selfdrive/navd/tpl/addr_input.tpl
+++ b/selfdrive/navd/tpl/addr_input.tpl
@@ -1,8 +1,15 @@
 <form name="searchForm" method="post">
     <fieldset class="uk-fieldset">
         <div class="uk-margin">
-            <input class="uk-input" type="text" name="addr_val" placeholder="Search a place">
+            <select class="uk-select" name="fav_val">
+                <option value="favorites">Select Saved Destinations</option>
+                <option value="home">Home</option>
+                <option value="work">Work</option>
+                <option value="fav1">Favorite 1</option>
+                <option value="fav2">Favorite 2</option>
+                <option value="fav3">Favorite 3</option>
             <div style="padding: 5px; color: red; font-weight: bold;" align="center">{{msg}}</div>
+            <input class="uk-input" type="text" name="addr_val" placeholder="Search a place">
             <input class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom" type="submit" value="Search">
         </div>
     </fieldset>

--- a/selfdrive/navd/tpl/nav_confirmation.tpl
+++ b/selfdrive/navd/tpl/nav_confirmation.tpl
@@ -8,8 +8,11 @@
           <input type="hidden" name="lon" value="{{lon}}">
           <select id="save_type" name="save_type" class="uk-select">
             <option value="recent">Recent</option>
-            <option value="home">Home</option>
-            <option value="work">Work</option>
+            <option value="home">Set Home</option>
+            <option value="work">Set Work</option>
+            <option value="fav1">Set Favorite 1</option>
+            <option value="fav2">Set Favorite 2</option>
+            <option value="fav3">Set Favorite 3</option>
           </select>
           <input class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom" type="submit" value="Start Navigation">
         </div>


### PR DESCRIPTION
Small enhancements to the non-prime navigation web interface with the following:

    Ability to select existing home/week saved destinations that were stored in param ApiCache_NavDestinations from new dropdown
    Ability to add 3 other favorite destinations that are stored in param ApiCache_NavDestinations with labels
    On nav_confirmation template, added the word "Set" to separate action from main page. e.g. "Set Home", "Set Work" etc.
![osi1](https://github.com/sunnyhaibin/sunnypilot/assets/98910897/cfa88ad2-6a27-40cf-95cc-418d863042fa)
![osi2](https://github.com/sunnyhaibin/sunnypilot/assets/98910897/bd6d5443-d8d3-423d-9561-4bc4464087f8)
![osi3](https://github.com/sunnyhaibin/sunnypilot/assets/98910897/2c3a5445-f56d-4620-b20d-37fb6c5c9225)
