### PR TITLE
Added finger print for ICE Kia Sportage in AUS and NZ KIA_SPORTAGE_5TH_GEN

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -1943,11 +1943,13 @@ FW_VERSIONS = {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NQ5 FR_CMR AT USA LHD 1.00 1.00 99211-P1030 662',
       b'\xf1\x00NQ5 FR_CMR AT USA LHD 1.00 1.00 99211-P1040 663',
+      b'\xf1\x00NQ5 FR_CMR AT AUS RHD 1.00 1.00 99211-P1040 663',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NQ5__               1.00 1.02 99110-P1000         ',
       b'\xf1\x00NQ5__               1.00 1.03 99110-P1000         ',
       b'\xf1\x00NQ5__               1.01 1.03 99110-P1000         ',
+      b'\xf1\x00NQ5__               1.00 1.03 99110-P1000         ',
     ],
   },
   CAR.GENESIS_GV70_1ST_GEN: {


### PR DESCRIPTION
Added finger print for ICE Kia Sportage in AUS and NZ KIA_SPORTAGE_5TH_GEN

<!--- ***** Template: Car port *****

**Checklist**
- [X ] added entry to CarInfo in selfdrive/car/*/values.py 
-->
