### PR TITLE
Breakout Ford F150 Lightning 

### DIFF
--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -4,7 +4,7 @@ from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.ford.fordcan import CanBus
-from openpilot.selfdrive.car.ford.values import CANFD_CAR, CarControllerParams, DBC
+from openpilot.selfdrive.car.ford.values import CANFD_CAR, FORD_EV, CarControllerParams, DBC
 
 GearShifter = car.CarState.GearShifter
 TransmissionType = car.CarParams.TransmissionType
@@ -26,7 +26,11 @@ class CarState(CarStateBase):
     # Hybrid variants experience a bug where a message from the PCM sends invalid checksums,
     # we do not support these cars at this time.
     # TrnAin_Tq_Actl and its quality flag are only set on ICE platform variants
-    self.hybrid_platform = cp.vl["VehicleOperatingModes"]["TrnAinTq_D_Qf"] == 0
+    # EVs have not experienced this same issue but have the flag. Defaulting to false for now.
+    if self.CP.carFingerprint in FORD_EV:
+      self.hybrid_platform = False # cp.vl["VehicleOperatingModes"]["TrnAinTq_D_Qf"] == 0
+    else:
+      self.hybrid_platform = cp.vl["VehicleOperatingModes"]["TrnAinTq_D_Qf"] == 0
 
     # Occasionally on startup, the ABS module recalibrates the steering pinion offset, so we need to block engagement
     # The vehicle usually recovers out of this state within a minute of normal driving

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -56,7 +56,7 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 17.0
       ret.mass = 2000
 
-    elif candidate == CAR.F_150_MK14:
+    elif candidate == CAR.F_150_LIGHTNING_MK1:
       # required trim only on SuperCrew
       ret.wheelbase = 3.69
       ret.steerRatio = 17.0

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -14,7 +14,7 @@ class CarInterface(CarInterfaceBase):
   @staticmethod
   def _get_params(ret, candidate, fingerprint, car_fw, experimental_long, docs):
     ret.carName = "ford"
-    ret.dashcamOnly = candidate in {CAR.F_150_MK14}
+    ret.dashcamOnly = candidate in {CAR.F_150_MK14, CAR.F_150_LIGHTNING_MK1}
 
     ret.radarUnavailable = True
     ret.steerControlType = car.CarParams.SteerControlType.angle
@@ -55,6 +55,12 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 3.69
       ret.steerRatio = 17.0
       ret.mass = 2000
+
+    elif candidate == CAR.F_150_MK14:
+      # required trim only on SuperCrew
+      ret.wheelbase = 3.69
+      ret.steerRatio = 17.0
+      ret.mass = 2729
 
     elif candidate == CAR.FOCUS_MK4:
       ret.wheelbase = 2.7

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -47,9 +47,11 @@ class CAR:
   F_150_MK14 = "FORD F-150 14TH GEN"
   FOCUS_MK4 = "FORD FOCUS 4TH GEN"
   MAVERICK_MK1 = "FORD MAVERICK 1ST GEN"
+  F_150_LIGHTNING_MK1 = "FORD F-150 LIGHTNING 1ST GEN"
 
 
-CANFD_CAR = {CAR.F_150_MK14}
+CANFD_CAR = {CAR.F_150_MK14, CAR.F_150_LIGHTNING_MK1}
+FORD_EV = {CAR.F_150_LIGHTNING_MK1}
 
 
 class RADAR:
@@ -60,7 +62,7 @@ class RADAR:
 DBC: Dict[str, Dict[str, str]] = defaultdict(lambda: dbc_dict("ford_lincoln_base_pt", RADAR.DELPHI_MRR))
 
 # F-150 radar is not yet supported
-DBC[CAR.F_150_MK14] = dbc_dict("ford_lincoln_base_pt", None)
+DBC[CAR.F_150_MK14, CAR.F_150_LIGHTNING_MK1] = dbc_dict("ford_lincoln_base_pt", None)
 
 
 class Footnote(Enum):
@@ -79,6 +81,8 @@ class FordCarInfo(CarInfo):
   def init_make(self, CP: car.CarParams):
     if CP.carFingerprint in (CAR.BRONCO_SPORT_MK1, CAR.MAVERICK_MK1):
       self.car_parts = CarParts([Device.three_angled_mount, CarHarness.ford_q3])
+    if CP.carFingerprint in (CAR.F_150_LIGHTNING_MK1):
+      self.car_parts = CarParts([Device.three_angled_mount, CarHarness.ford_q4])
 
 
 CAR_INFO: Dict[str, Union[CarInfo, List[CarInfo]]] = {
@@ -92,6 +96,7 @@ CAR_INFO: Dict[str, Union[CarInfo, List[CarInfo]]] = {
     FordCarInfo("Lincoln Aviator 2020-21", "Co-Pilot360 Plus"),
   ],
   CAR.F_150_MK14: FordCarInfo("Ford F-150 2023", "Co-Pilot360 Active 2.0"),
+  CAR.F_150_LIGHTNING_MK1: FordCarInfo("Ford F-150 Lightning 2022", "Co-Pilot360 Active 2.0"),
   CAR.FOCUS_MK4: FordCarInfo("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),
   CAR.MAVERICK_MK1: [
     FordCarInfo("Ford Maverick 2022", "LARIAT Luxury"),
@@ -211,6 +216,11 @@ FW_VERSIONS = {
       b'MB5A-14C204-RC\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'NB5A-14C204-AZD\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'NB5A-14C204-HB\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+    ],
+  },
+  CAR.F_150_LIGHTNING_MK1: {
+    (Ecu.shiftByWire, 0x732, None): [
+      b'ML3P-7P470-AK\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
   },
   CAR.F_150_MK14: {

--- a/selfdrive/car/torque_data/override.yaml
+++ b/selfdrive/car/torque_data/override.yaml
@@ -21,6 +21,7 @@ FORD BRONCO SPORT 1ST GEN: [.nan, 1.5, .nan]
 FORD ESCAPE 4TH GEN: [.nan, 1.5, .nan]
 FORD EXPLORER 6TH GEN: [.nan, 1.5, .nan]
 FORD F-150 14TH GEN: [.nan, 1.5, .nan]
+FORD F-150 LIGHTNING 1ST GEN: [.nan, 1.5, .nan]
 FORD FOCUS 4TH GEN: [.nan, 1.5, .nan]
 FORD MAVERICK 1ST GEN: [.nan, 1.5, .nan]
 ###


### PR DESCRIPTION
Ford F150 MK14 and Ford F150 Lightning share the same controls but have different ECUs (for now; this could change with CAN-FD fingerprinting working later), and have different weights.

I've added support to properly identify an F150 Lightning.

This still puts the vehicle into dashcam only mode, though I think it might be worth removing it from dashcam only.