### PR TITLE
fix: nnff require perfect match for car (not eps)

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -160,10 +160,10 @@ def get_nn_model_path(_car, eps_firmware) -> Tuple[Optional[str], float]:
   else:
     check_model = _car
   model_path, max_similarity = check_nn_path(check_model)
-  if 0.0 <= max_similarity < 0.9:
+  if _car not in model_path or 0.0 <= max_similarity < 0.9:
     check_model = _car
     model_path, max_similarity = check_nn_path(check_model)
-    if 0.0 <= max_similarity < 0.9:
+    if _car not in model_path or 0.0 <= max_similarity < 0.9:
       model_path = None
   return model_path, max_similarity
 


### PR DESCRIPTION
requires exact match of car fingerprint in the NNLC model path, making it so that "fuzzy" matches are only allowed for the eps firmware string.